### PR TITLE
change router to hash

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -29,7 +29,7 @@ const routes = [
 
 const router = new VueRouter({
   routes,
-  mode: 'history'
+  mode: 'hash'
 })
 
 export default router


### PR DESCRIPTION
'hash' works better with subpaths in non-isometric projects (relative http calls are working while using hash mode)