### PR TITLE
Fix bug mutating ProductVisibility

### DIFF
--- a/backend/internal/models/jsonSchemas/message.json
+++ b/backend/internal/models/jsonSchemas/message.json
@@ -155,7 +155,10 @@
       "then": {
         "properties": {
           "payload": {
-            "$ref": "sql/queryResult.json"
+            "anyOf": [
+              { "$ref": "sql/queryResult.json" },
+              { "$ref": "sql/queryResultList.json" }
+            ]
           }
         }
       }

--- a/backend/internal/models/productVisibility.go
+++ b/backend/internal/models/productVisibility.go
@@ -15,9 +15,9 @@ import (
 // to which categories at which locations.
 type ProductVisibility struct {
 	Id         int `json:"id" db:"product_visibility_id"`
-	CategoryId int `json:"category" db:"category"`
-	LocationId int `json:"location" db:"location"`
-	ProductId  int `json:"product" db:"product"`
+	CategoryId int `json:"categoryId" db:"category"`
+	LocationId int `json:"locationId" db:"location"`
+	ProductId  int `json:"productId" db:"product"`
 }
 
 // ProductVisibilityModel provides database operations for ProductVisibility entities.

--- a/backend/internal/ws/conversion.go
+++ b/backend/internal/ws/conversion.go
@@ -75,8 +75,18 @@ func (s *Service) marshalResultMutation(table models.TableName, operation models
 	return s.marshalAndValidateMessage(&msg)
 }
 
-func (s *Service) marshalBroadcastWithPayload(table models.TableName, data []byte) ([]byte, *models.WsError) {
+func (s *Service) marshalBroadcastQueryResult(table models.TableName, data json.RawMessage) ([]byte, *models.WsError) {
 	res := models.QueryResult{Table: table, Data: data}
+	msg := models.Message{
+		Type:    models.MsgTypeBroadcast,
+		Payload: res,
+	}
+
+	return s.marshalAndValidateMessage(&msg)
+}
+
+func (s *Service) marshalBroadcastQueryResultList(table models.TableName, data *[]json.RawMessage) ([]byte, *models.WsError) {
+	res := models.QueryResultList{Table: table, Data: *data}
 	msg := models.Message{
 		Type:    models.MsgTypeBroadcast,
 		Payload: res,

--- a/backend/internal/ws/processor.go
+++ b/backend/internal/ws/processor.go
@@ -263,7 +263,7 @@ func (s *Service) processMutation(mutation *models.Mutation) ([]byte, int, *mode
 }
 
 func (s *Service) prepareBroadcast(mutation *models.Mutation, id int) ([]byte, *models.WsError) {
-	var data []byte
+	var queryResultList []json.RawMessage
 	switch mutation.Table {
 	case models.TableAccount:
 		var account *models.Account
@@ -275,7 +275,8 @@ func (s *Service) prepareBroadcast(mutation *models.Mutation, id int) ([]byte, *
 				Details: fmt.Sprintf("Could not get account with ID %d", id)}
 			return nil, wsErr
 		}
-		data, _ = json.Marshal(account)
+		rawAcc, _ := json.Marshal(account)
+		queryResultList = append(queryResultList, rawAcc)
 
 	case models.TableProductVisibility:
 		query := models.Query{
@@ -289,13 +290,26 @@ func (s *Service) prepareBroadcast(mutation *models.Mutation, id int) ([]byte, *
 				Details: "Could not reload product visibilities after delete",
 			}
 		}
-		data, _ = json.Marshal(visibilities)
+		for _, vis := range visibilities {
+			rawVis, _ := json.Marshal(vis)
+			queryResultList = append(queryResultList, rawVis)
+		}
+
+	} // end of switch
+
+	if len(queryResultList) == 1 {
+		message, wsErr := s.marshalBroadcastQueryResult(mutation.Table, queryResultList[0])
+		if wsErr != nil {
+			return nil, wsErr
+		}
+		return message, nil
+	} else if len(queryResultList) > 1 {
+		message, wsErr := s.marshalBroadcastQueryResultList(mutation.Table, &queryResultList)
+		if wsErr != nil {
+			return nil, wsErr
+		}
+		return message, nil
 	}
 
-	message, wsErr := s.marshalBroadcastWithPayload(mutation.Table, data)
-	if wsErr != nil {
-		return nil, wsErr
-	}
-
-	return message, nil
+	return nil, &models.WsError{Code: models.WsUnknown, Message: "Broadcast data is empty"}
 }

--- a/frontend/src/api/webSocketClient.ts
+++ b/frontend/src/api/webSocketClient.ts
@@ -10,6 +10,7 @@ import {useVatStore} from "../store/VatStore.ts";
 import {useProductStore} from "../store/ProductStore.ts";
 import {useLocationStore} from "../store/LocationStore.ts";
 import {useProductVisibilityStore} from "../store/ProductVisibilityStore.ts";
+import type { ProductVisibility } from "../composables/productVisibility.ts";
 
 interface WebSocketClientOptions {
     reconnectInterval?: number;
@@ -233,6 +234,11 @@ export class WebSocketClient {
                             newAccounts.push(result.data as Account);
                             useAccountStore().patchAccounts(newAccounts);
                             // TODO do stuff
+                            return;
+                        }
+                        case 'product_visibility': {
+                            let newVisibilities = result.data as ProductVisibility[];
+                            useProductVisibilityStore().patchVisibilities(newVisibilities);
                             return;
                         }
                     }

--- a/frontend/src/composables/productVisibility.ts
+++ b/frontend/src/composables/productVisibility.ts
@@ -7,9 +7,9 @@ import {useProductStore} from "../store/ProductStore.ts";
 
 export interface ProductVisibility {
     id?: number
-    category: number
-    location: number
-    product: number
+    categoryId: number
+    locationId: number
+    productId: number
     getCategory(): Category
     getProduct(): Product
     getLocation(): Location
@@ -19,21 +19,21 @@ export class ProductVisibility implements ProductVisibility {
 
     constructor(vis: ProductVisibility) {
         this.id = vis.id;
-        this.category = vis.category;
-        this.location = vis.location;
-        this.product = vis.product;
+        this.categoryId = vis.categoryId;
+        this.locationId = vis.locationId;
+        this.productId = vis.productId;
     }
 
     public getCategory(): Category | undefined{
-        return useCategoryStore().byId(this.category)
+        return useCategoryStore().byId(this.categoryId)
     }
 
     public getProduct(): Product | undefined{
-        return useProductStore().byId(this.product)
+        return useProductStore().byId(this.productId)
     }
 
     public getLocation(): Location | undefined{
-        return useLocationStore().byId(this.location)
+        return useLocationStore().byId(this.locationId)
     }
 
 }

--- a/frontend/src/store/ProductStore.ts
+++ b/frontend/src/store/ProductStore.ts
@@ -24,7 +24,7 @@ export const useProductStore = defineStore('product', {
                 let visibilities = useProductVisibilityStore().byProductId(prod.id)
                 let retVal = false;
                 visibilities.forEach((visi) => {
-                    if (selectedAccountCategorys.includes(visi.category)) { 
+                    if (selectedAccountCategorys.includes(visi.categoryId)) { 
                         retVal = true;
                         return
                     } 

--- a/frontend/src/store/ProductVisibilityStore.ts
+++ b/frontend/src/store/ProductVisibilityStore.ts
@@ -45,14 +45,10 @@ export const useProductVisibilityStore = defineStore('product_visibility', {
         },
         patchVisibilities(newVisibilities: ProductVisibility[]) {
             this.$patch(state => {
+                state.visibilities = [];
                 newVisibilities.forEach(newVis => {
                     const newVisObj = new ProductVisibility(newVis);
-                    const existing = state.visibilities.find(a => a.id === newVisObj.id);
-                    if (existing) {
-                        Object.assign(existing, newVisObj);
-                    } else {
-                        state.visibilities.push(newVisObj);
-                    }
+                    state.visibilities.push(newVisObj);
                 })
             })
         }

--- a/frontend/src/store/ProductVisibilityStore.ts
+++ b/frontend/src/store/ProductVisibilityStore.ts
@@ -19,14 +19,14 @@ export const useProductVisibilityStore = defineStore('product_visibility', {
         },
         byProductId(id: number){
             let foundVis = this.visibilities.filter((vis) => {
-                return vis.product == id;
+                return vis.productId == id;
             })
             return foundVis;
         },
         categoryIsVisible(categoryId: number, productId: number): boolean{
             let returnValue = false;
             this.byProductId(productId).forEach((vis) => {
-                if(vis.category == categoryId) {
+                if(vis.categoryId == categoryId) {
                     returnValue = true;
                 }
             })
@@ -34,13 +34,13 @@ export const useProductVisibilityStore = defineStore('product_visibility', {
         },
         toggleCategoryVisibility(categoryId: number, productId: number){
             let productVis = this.byProductId(productId);
-            let categoryVis = productVis.filter((vis) => { return vis.category == categoryId});
+            let categoryVis = productVis.filter((vis) => { return vis.categoryId == categoryId});
             if(categoryVis.length > 0) {
                 // this.visibilities = this.visibilities.filter((vis) => { return vis != categoryVis[0]});
                 useSocketStore().removeVisibility(categoryVis[0].id);
                 return
             }
-            let newVis = {'category': categoryId, 'product': productId, 'location': 1} as ProductVisibility;
+            let newVis = {'categoryId': categoryId, 'productId': productId, 'locationId': 1} as ProductVisibility;
             useSocketStore().addVisibility(newVis);
         },
         patchVisibilities(newVisibilities: ProductVisibility[]) {


### PR DESCRIPTION
The `message.json` schema previously only allowed a `queryResult` in a broadcast. Now it also supports `queryResultList`. I also adjusted the processing logic in the backend accordingly.

Other than that, I renamed the fields of the `ProductVisibility` (e.g. `category` → `categoryId`) as this better reflects the intent, since we're passing IDs rather than full objects. Feel free to adjust if you disagree :).

Finally, I've noticed another issue that you probably are already aware of: when we (de)select the visibility, the UI form is not refreshed. This results in two different behaviors:
1. if the category is visible and we deselect it *n* times, it tries to delete the same object *n* times from the database (which succeeds the first time and fails *n-1* times)
2. if the category is not visible and we select it *n* times, it will create *n* times the same entry in the database.
