### PR TITLE
Add Catppuccin theming and UI polish

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,7 +10,8 @@
     import MainNavigation from './components/MainNavigation.vue';
   import DevModeBar from './components/DevModeBar.vue';
   import { useSocketStore } from './store/socketStore';
-  
+  import { useThemeStore } from './store/themeStore';
+
   export default {
     components: {
       MainNavigation,
@@ -20,9 +21,11 @@
       return {
         dev: false,
         socket$: useSocketStore(),
+        theme$: useThemeStore(),
       }
     },
     mounted() {
+        this.theme$.init();
         this.dev = import.meta.env.DEV;
         this.socket$.getAllFromDb();
     }

--- a/frontend/src/assets/catppuccin.scss
+++ b/frontend/src/assets/catppuccin.scss
@@ -33,7 +33,7 @@ html[data-theme="catppuccin-latte"] {
   // Danger → Red #d20f39
   --bulma-danger-h: 347deg;
   --bulma-danger-s: 87%;
-  --bulma-danger-l: 44%;
+  --bulma-danger-l: 44%; //44
   // Warning → Yellow #df8e1d
   --bulma-warning-h: 35deg;
   --bulma-warning-s: 77%;
@@ -42,6 +42,12 @@ html[data-theme="catppuccin-latte"] {
   --bulma-info-h: 197deg;
   --bulma-info-s: 97%;
   --bulma-info-l: 46%;
+  
+  // Repariere kaputte Farben
+  --bulma-danger-on-scheme-l: 0%;
+  --bulma-info-on-scheme-1: 0%;
+  --bulma-primary-invert-1: 100%;
+  --bulma-info-invert-1: 100%;
 }
 
 html[data-theme="catppuccin-frappe"] {

--- a/frontend/src/assets/catppuccin.scss
+++ b/frontend/src/assets/catppuccin.scss
@@ -1,0 +1,177 @@
+html[data-theme="catppuccin-latte"] {
+  // Scheme (backgrounds)
+  --bulma-scheme-h: 220;
+  --bulma-scheme-s: 23%;
+  --bulma-scheme-main-l: 95%;        // Base #eff1f5
+  --bulma-scheme-main-bis-l: 92%;    // Mantle #e6e9ef
+  --bulma-scheme-main-ter-l: 89%;    // Crust #dce0e8
+  --bulma-scheme-invert-l: 35%;
+  --bulma-scheme-invert-bis-l: 29%;
+  --bulma-scheme-invert-ter-l: 47%;
+  --bulma-background-l: 83%;         // Surface0 #ccd0da
+  --bulma-border-l: 77%;             // Surface1 #bcc0cc
+  --bulma-border-weak-l: 83%;
+  // Text
+  --bulma-text-h: 234deg;
+  --bulma-text-s: 16%;
+  --bulma-text-l: 35%;               // Text #4c4f69
+  --bulma-text-weak-l: 47%;          // Subtext0 #6c6f85
+  --bulma-text-strong-l: 21%;
+  --bulma-text-title-l: 14%;
+  // Primary → Sky #04a5e5
+  --bulma-primary-h: 197deg;
+  --bulma-primary-s: 97%;
+  --bulma-primary-l: 46%;
+  // Link → Blue #1e66f5
+  --bulma-link-h: 220deg;
+  --bulma-link-s: 91%;
+  --bulma-link-l: 54%;
+  // Success → Green #40a02b
+  --bulma-success-h: 109deg;
+  --bulma-success-s: 58%;
+  --bulma-success-l: 40%;
+  // Danger → Red #d20f39
+  --bulma-danger-h: 347deg;
+  --bulma-danger-s: 87%;
+  --bulma-danger-l: 44%;
+  // Warning → Yellow #df8e1d
+  --bulma-warning-h: 35deg;
+  --bulma-warning-s: 77%;
+  --bulma-warning-l: 49%;
+  // Info → Sky #04a5e5
+  --bulma-info-h: 197deg;
+  --bulma-info-s: 97%;
+  --bulma-info-l: 46%;
+}
+
+html[data-theme="catppuccin-frappe"] {
+  --bulma-scheme-h: 229;
+  --bulma-scheme-s: 19%;
+  --bulma-scheme-main-l: 23%;        // Base #303446
+  --bulma-scheme-main-bis-l: 20%;    // Mantle #292c3c
+  --bulma-scheme-main-ter-l: 17%;    // Crust #232634
+  --bulma-scheme-invert-l: 87%;
+  --bulma-scheme-invert-bis-l: 92%;
+  --bulma-scheme-invert-ter-l: 73%;
+  --bulma-background-l: 30%;         // Surface0 #414559
+  --bulma-border-l: 37%;             // Surface1 #51576d
+  --bulma-border-weak-l: 30%;
+  --bulma-text-h: 227deg;
+  --bulma-text-s: 70%;
+  --bulma-text-l: 87%;               // Text #c6d0f5
+  --bulma-text-weak-l: 73%;          // Subtext0 #a5adce
+  --bulma-text-strong-l: 95%;
+  --bulma-text-title-l: 99%;
+  // Primary → Sky #99d1db
+  --bulma-primary-h: 189deg;
+  --bulma-primary-s: 48%;
+  --bulma-primary-l: 73%;
+  // Link → Blue #8caaee
+  --bulma-link-h: 222deg;
+  --bulma-link-s: 74%;
+  --bulma-link-l: 74%;
+  // Success → Green #a6d189
+  --bulma-success-h: 96deg;
+  --bulma-success-s: 44%;
+  --bulma-success-l: 68%;
+  // Danger → Red #e78284
+  --bulma-danger-h: 359deg;
+  --bulma-danger-s: 68%;
+  --bulma-danger-l: 71%;
+  // Warning → Yellow #e5c890
+  --bulma-warning-h: 40deg;
+  --bulma-warning-s: 62%;
+  --bulma-warning-l: 73%;
+  // Info → Sky #99d1db
+  --bulma-info-h: 189deg;
+  --bulma-info-s: 48%;
+  --bulma-info-l: 73%;
+}
+
+html[data-theme="catppuccin-macchiato"] {
+  --bulma-scheme-h: 232;
+  --bulma-scheme-s: 23%;
+  --bulma-scheme-main-l: 18%;        // Base #24273a
+  --bulma-scheme-main-bis-l: 15%;    // Mantle #1e2030
+  --bulma-scheme-main-ter-l: 12%;    // Crust #181926
+  --bulma-scheme-invert-l: 87%;
+  --bulma-scheme-invert-bis-l: 92%;
+  --bulma-scheme-invert-ter-l: 72%;
+  --bulma-background-l: 26%;         // Surface0 #363a4f
+  --bulma-border-l: 34%;             // Surface1 #494d64
+  --bulma-border-weak-l: 26%;
+  --bulma-text-h: 227deg;
+  --bulma-text-s: 68%;
+  --bulma-text-l: 88%;               // Text #cad3f5
+  --bulma-text-weak-l: 72%;          // Subtext0 #a5adcb
+  --bulma-text-strong-l: 95%;
+  --bulma-text-title-l: 99%;
+  // Primary → Sky #91d7e3
+  --bulma-primary-h: 189deg;
+  --bulma-primary-s: 59%;
+  --bulma-primary-l: 73%;
+  // Link → Blue #8aadf4
+  --bulma-link-h: 220deg;
+  --bulma-link-s: 83%;
+  --bulma-link-l: 75%;
+  // Success → Green #a6da95
+  --bulma-success-h: 105deg;
+  --bulma-success-s: 48%;
+  --bulma-success-l: 72%;
+  // Danger → Red #ed8796
+  --bulma-danger-h: 351deg;
+  --bulma-danger-s: 74%;
+  --bulma-danger-l: 73%;
+  // Warning → Yellow #eed49f
+  --bulma-warning-h: 38deg;
+  --bulma-warning-s: 72%;
+  --bulma-warning-l: 78%;
+  // Info → Sky #91d7e3
+  --bulma-info-h: 189deg;
+  --bulma-info-s: 59%;
+  --bulma-info-l: 73%;
+}
+
+html[data-theme="catppuccin-mocha"] {
+  --bulma-scheme-h: 240;
+  --bulma-scheme-s: 21%;
+  --bulma-scheme-main-l: 15%;        // Base #1e1e2e
+  --bulma-scheme-main-bis-l: 12%;    // Mantle #181825
+  --bulma-scheme-main-ter-l: 9%;     // Crust #11111b
+  --bulma-scheme-invert-l: 88%;
+  --bulma-scheme-invert-bis-l: 93%;
+  --bulma-scheme-invert-ter-l: 72%;
+  --bulma-background-l: 23%;         // Surface0 #313244
+  --bulma-border-l: 31%;             // Surface1 #45475a
+  --bulma-border-weak-l: 23%;
+  --bulma-text-h: 226deg;
+  --bulma-text-s: 64%;
+  --bulma-text-l: 88%;               // Text #cdd6f4
+  --bulma-text-weak-l: 72%;          // Subtext0 #a6adc8
+  --bulma-text-strong-l: 95%;
+  --bulma-text-title-l: 99%;
+  // Primary → Sky #89dceb
+  --bulma-primary-h: 189deg;
+  --bulma-primary-s: 71%;
+  --bulma-primary-l: 73%;
+  // Link → Blue #89b4fa
+  --bulma-link-h: 217deg;
+  --bulma-link-s: 92%;
+  --bulma-link-l: 76%;
+  // Success → Green #a6e3a1
+  --bulma-success-h: 115deg;
+  --bulma-success-s: 54%;
+  --bulma-success-l: 76%;
+  // Danger → Red #f38ba8
+  --bulma-danger-h: 343deg;
+  --bulma-danger-s: 81%;
+  --bulma-danger-l: 75%;
+  // Warning → Yellow #f9e2af
+  --bulma-warning-h: 40deg;
+  --bulma-warning-s: 88%;
+  --bulma-warning-l: 83%;
+  // Info → Sky #89dceb
+  --bulma-info-h: 189deg;
+  --bulma-info-s: 71%;
+  --bulma-info-l: 73%;
+}

--- a/frontend/src/assets/style.scss
+++ b/frontend/src/assets/style.scss
@@ -1,3 +1,9 @@
 @import "./variables.scss";
 @import "bulma/bulma";
 @import "./catppuccin.scss";
+
+.tag {
+  white-space: break-spaces;
+  height:auto;
+  min-height:2em;
+}

--- a/frontend/src/assets/style.scss
+++ b/frontend/src/assets/style.scss
@@ -1,2 +1,3 @@
 @import "./variables.scss";
 @import "bulma/bulma";
+@import "./catppuccin.scss";

--- a/frontend/src/assets/variables.scss
+++ b/frontend/src/assets/variables.scss
@@ -1,8 +1,3 @@
-:root{
-  --primary: hsl(110, 76%, 59%);
-}
-
-
 * {
   user-select: none;
 }
@@ -11,7 +6,3 @@
   user-select: text;
 }
 
-.button.is-primary,
-.tag.is-primary{
-  background-color: var(--primary);
-}

--- a/frontend/src/components/AccountPaymentCard.vue
+++ b/frontend/src/components/AccountPaymentCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="panel" v-if="account$.selected.length > 0">
+  <div class="panel is-primary" v-if="account$.selected.length > 0">
     <div class="panel-heading">
       <span>{{ account$.selected[0].getFullName() }}</span>
       <button class="delete" aria-label="delete" @click="account$.unselect();"></button>
@@ -14,7 +14,7 @@
         </div>
         <div class="balance-area">
           <span>Balance</span><br>
-          <span class="balance">{{ $n(account$.selected[0].balance / 100, 'currency', 'de-DE') }}</span>
+          <span class="balance" :class="account$.selected[0].balance < 0 ? 'has-text-danger' : 'has-text-primary'">{{ $n(account$.selected[0].balance / 100, 'currency', 'de-DE') }}</span>
         </div>
       </div>
 
@@ -23,7 +23,7 @@
           List Orders
         </Button>
 
-        <Button class="is-success is-inverted is-outlined" :fa-icon="['fas', 'coins']" icon-position="right">
+        <Button class="is-success" :fa-icon="['fas', 'coins']" icon-position="right">
           Pay now
         </Button>
       </Buttons>
@@ -70,6 +70,7 @@
   display:grid;
   grid-template-columns: 1.5rem auto;
   align-items: center;
+  gap: 0.1rem 0.25rem;
 }
 .columns{
   width:100%;
@@ -78,12 +79,18 @@
   max-width: 80ch;
   margin-inline: auto;
   position:relative;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+}
+.panel-heading{
+  font-size:1.05rem;
+  letter-spacing: 0.02em;
 }
 .panel-block{
   display:block;
+  background-color: hsl(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-scheme-main-l));
 }
 .buttons{
-  margin-top:.5rem;
+  margin-top:.75rem;
   justify-content: end;
 }
 .balance-area{
@@ -91,7 +98,7 @@
 }
 .balance{
   font-size:2rem;
-  font-weight:600;
+  font-weight:700;
 }
 .delete{
   position:absolute;

--- a/frontend/src/components/AccountPaymentCard.vue
+++ b/frontend/src/components/AccountPaymentCard.vue
@@ -14,7 +14,7 @@
         </div>
         <div class="balance-area">
           <span>Balance</span><br>
-          <span class="balance" :class="account$.selected[0].balance < 0 ? 'has-text-danger' : 'has-text-primary'">{{ $n(account$.selected[0].balance / 100, 'currency', 'de-DE') }}</span>
+          <span class="balance" :class="account$.selected[0].balance <= (-1* account$.selected[0].maxDebt) ? 'has-text-danger' : 'has-text-primary'">{{ $n(account$.selected[0].balance / 100, 'currency', 'de-DE') }}</span>
         </div>
       </div>
 

--- a/frontend/src/components/MainNavigation.vue
+++ b/frontend/src/components/MainNavigation.vue
@@ -46,6 +46,7 @@
     </div>
 
     <div class="navbar-end">
+      <ThemeSelector />
       <div class="navbar-item">
         <div class="buttons">
           <a class="button is-light">
@@ -59,7 +60,10 @@
 </template>
 
 <script lang="ts">
+  import ThemeSelector from './ThemeSelector.vue'
+
   export default {
+    components: { ThemeSelector },
     data() {
       return {
         burgerActive: false as Boolean

--- a/frontend/src/components/OrderViewer/CartControl.vue
+++ b/frontend/src/components/OrderViewer/CartControl.vue
@@ -13,7 +13,7 @@
 
     <Button
     v-if="!cart$.isOverdrawn"
-    class="is-success"
+    class="is-primary"
     @click="checkoutOrder"
     title="discard cart and unselect account"
     :fa-icon="['fas', 'beer']"

--- a/frontend/src/components/OrderViewer/CartControl.vue
+++ b/frontend/src/components/OrderViewer/CartControl.vue
@@ -2,7 +2,7 @@
 
   <Buttons>
     <Button
-    class="is-warning is-inverted is-outlined"
+    class="is-warning"
     @click="$emit('cancelOrder')"
     title="discard cart and unselect account"
     :fa-icon="['fas', 'trash']"
@@ -13,8 +13,8 @@
 
     <Button
     v-if="!cart$.isOverdrawn"
-    class="is-success is-inverted is-outlined"
-    @click="checkoutOrder" 
+    class="is-success"
+    @click="checkoutOrder"
     title="discard cart and unselect account"
     :fa-icon="['fas', 'beer']"
     icon-position="right"
@@ -24,7 +24,7 @@
 
     <Button
     v-if="cart$.isOverdrawn"
-    class="is-inverted is-danger is-outlined"
+    class="is-danger"
     title="discard cart and unselect account"
     :fa-icon="['fas', 'coins']"
     icon-position="right"

--- a/frontend/src/components/OrderViewer/CartList.vue
+++ b/frontend/src/components/OrderViewer/CartList.vue
@@ -28,16 +28,27 @@
 <style scoped>
 .table-container{
   border-radius: var(--bulma-control-radius);
-  margin-bottom:.5rem;
+  margin-bottom:.75rem;
+  border: 1px solid hsl(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-border-l));
+  overflow: hidden;
   .table{
     width:100%;
+    background-color: transparent;
+    margin-bottom:0;
   }
 }
 .dblhr{
-  --_height:6px;
-  height:var(--_height);
-  border-top:calc(var(--_height) / 3) solid var(--bulma-scheme-main);;
-  border-bottom:calc(var(--_height) / 3) solid var(--bulma-scheme-main);;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)) 20%,
+    hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)) 80%,
+    transparent
+  );
+  opacity: 0.5;
+  margin-bottom: .75rem;
+  border: none;
 }
 </style>
 

--- a/frontend/src/components/OrderViewer/CartList.vue
+++ b/frontend/src/components/OrderViewer/CartList.vue
@@ -30,25 +30,19 @@
   border-radius: var(--bulma-control-radius);
   margin-bottom:.75rem;
   border: 1px solid hsl(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-border-l));
-  overflow: hidden;
+
   .table{
     width:100%;
-    background-color: transparent;
+    /* background-color: transparent; */
     margin-bottom:0;
   }
 }
-.dblhr{
-  height: 2px;
-  background: linear-gradient(
-    to right,
-    transparent,
-    hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)) 20%,
-    hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)) 80%,
-    transparent
-  );
-  opacity: 0.5;
-  margin-bottom: .75rem;
-  border: none;
+.dblhr{  
+  --_height:4px;
+  height:var(--_height);
+  border-top:calc(var(--_height) / 3) solid hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-strong-l));
+  border-bottom:calc(var(--_height) / 3) solid hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-strong-l));
+  margin-bottom: .5rem;
 }
 </style>
 

--- a/frontend/src/components/OrderViewer/CartProduct.vue
+++ b/frontend/src/components/OrderViewer/CartProduct.vue
@@ -3,7 +3,7 @@
     <td class="cell productQuantity">
       <div class="field has-addons">
         <p class="control">
-          <button class="button" @click="cart$.removeFromCart(content.product)"><icon :icon="['fas', 'trash']" /></button>
+          <button class="button is-danger is-light" @click="cart$.removeFromCart(content.product)"><icon :icon="['fas', 'trash']" /></button>
         </p>
         <p class="control has-icons-left has-icons-right">
           <input v-model="content.quantity" type="number" class="input"></input>

--- a/frontend/src/components/OrderViewer/CartProduct.vue
+++ b/frontend/src/components/OrderViewer/CartProduct.vue
@@ -3,7 +3,7 @@
     <td class="cell productQuantity">
       <div class="field has-addons">
         <p class="control">
-          <button class="button is-danger is-light" @click="cart$.removeFromCart(content.product)"><icon :icon="['fas', 'trash']" /></button>
+          <button class="button" @click="cart$.removeFromCart(content.product)"><icon :icon="['fas', 'trash']" /></button>
         </p>
         <p class="control has-icons-left has-icons-right">
           <input v-model="content.quantity" type="number" class="input"></input>
@@ -12,7 +12,7 @@
         </p>
       </div>
     </td>
-    <td class="cell productName"><span>{{ content.product.name }} ({{ content.product.size }})</span></td>
+    <td class="cell productName"><span>{{ content.product.name }} ({{ content.product.size }} {{ content.product.getUnit().name }})</span></td>
     <td class="cell productTax has-text-right"><span>{{ content.tax }}%</span></td>
     <td class="cell productPrice has-text-right"><span>{{ $n(content.price / 100, 'currency', 'de-DE') }}</span></td>
     <td class="cell productAmount has-text-right"><span>{{ $n(content.price * content.quantity / 100, 'currency', 'de-DE') }}</span></td>

--- a/frontend/src/components/OrderViewer/CartSums.vue
+++ b/frontend/src/components/OrderViewer/CartSums.vue
@@ -10,16 +10,22 @@
 </template>
 
 <style scoped>
-.cartSum,
-.cartTax{
-  font-size:1.2rem;
+.cartSum{
+  font-size:1.3rem;
   text-align: right;
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-strong-l));
   span{
-    font-weight:600;
+    font-weight:700;
+    color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l));
   }
 }
 .cartTax{
   font-size:.8rem;
+  text-align: right;
+  opacity: 0.65;
+  span{
+    font-weight:600;
+  }
 }
 </style>
 

--- a/frontend/src/components/OrderViewer/CartSums.vue
+++ b/frontend/src/components/OrderViewer/CartSums.vue
@@ -16,13 +16,13 @@
   color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-strong-l));
   span{
     font-weight:700;
-    color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l));
+    /* color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)); */
   }
 }
 .cartTax{
   font-size:.8rem;
   text-align: right;
-  opacity: 0.65;
+  /* opacity: 0.65; */
   span{
     font-weight:600;
   }

--- a/frontend/src/components/OrderViewer/OrderViewer.vue
+++ b/frontend/src/components/OrderViewer/OrderViewer.vue
@@ -12,7 +12,7 @@
 
     <div :class="showOrderDetails ? 'showDetails' : ''" class="message-body fixed-grid has-3-cols">
       <div class="selectedAccounts">
-        <div class="tag" v-for="account in account$.selected">
+        <div class="tag is-primary is-medium" v-for="account in account$.selected">
           {{ account.getFullName() }}
           <button class="delete is-small" @click="unselectAccount(account as Account)"></button>
         </div>
@@ -26,14 +26,12 @@
 
 <style scoped>
 
-.buttons{
-  justify-content: end;
-}
 .selectedAccounts{
-  margin-bottom:.5rem;
+  margin-bottom:.75rem;
 }
 .order{
   position:relative;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
 }
 .order-icon{
   margin-right:.5em;
@@ -49,12 +47,16 @@
 }
 .message-header{
   cursor:pointer;
+  font-size:1.05rem;
+  letter-spacing: 0.02em;
 }
 .message-body{
   display:none;
   position:absolute;
   width:100%;
   z-index:20;
+  background-color: hsl(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-scheme-main-l));
+  border-top: none;
 }
 .order-ripped-teaser{
   --_bg-color:hsl(var(--bulma-message-h),var(--bulma-message-s),var(--bulma-message-background-l));
@@ -98,6 +100,7 @@
   }
   .message-body{
     display:block;
+    position:static;
   }
 }
 </style>

--- a/frontend/src/components/OrderViewer/OrderViewer.vue
+++ b/frontend/src/components/OrderViewer/OrderViewer.vue
@@ -31,7 +31,6 @@
 }
 .order{
   position:relative;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
 }
 .order-icon{
   margin-right:.5em;
@@ -55,7 +54,8 @@
   position:absolute;
   width:100%;
   z-index:20;
-  background-color: hsl(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-scheme-main-l));
+  /* background-color: hsl(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-scheme-main-l)); */
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
   border-top: none;
 }
 .order-ripped-teaser{
@@ -86,6 +86,10 @@
     display:block;
   }
 }
+.tag{
+  margin-bottom:.25em;
+  margin-right:.25em;
+}
 @media screen and (min-width: 768px) {
   .order-icon,
   .showDetails.order-icon.details{
@@ -100,7 +104,7 @@
   }
   .message-body{
     display:block;
-    position:static;
+    /* position:static; */
   }
 }
 </style>

--- a/frontend/src/components/ThemeSelector.vue
+++ b/frontend/src/components/ThemeSelector.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="navbar-item has-dropdown is-hoverable">
+    <a class="navbar-link">{{ theme$.label }}</a>
+    <div class="navbar-dropdown">
+      <a v-for="t in themes" :key="t.key"
+         class="navbar-item" :class="{ 'is-active': theme$.currentTheme === t.key }"
+         @click="theme$.applyTheme(t.key)">
+        {{ t.label }}
+      </a>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.navbar-item.is-active {
+  background-color: transparent !important;
+  color: inherit !important;
+  font-weight: 600;
+  border-left: 3px solid hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l));
+  padding-left: calc(1rem - 3px);
+}
+</style>
+
+<script lang="ts">
+import { useThemeStore } from '../store/themeStore'
+
+export default {
+  data() {
+    return {
+      theme$: useThemeStore(),
+      themes: [
+        { key: 'catppuccin-latte',     label: 'Latte' },
+        { key: 'catppuccin-frappe',    label: 'Frappé' },
+        { key: 'catppuccin-macchiato', label: 'Macchiato' },
+        { key: 'catppuccin-mocha',     label: 'Mocha' },
+      ]
+    }
+  }
+}
+</script>

--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+
+type ThemeFlavor = 'catppuccin-latte' | 'catppuccin-frappe' | 'catppuccin-macchiato' | 'catppuccin-mocha'
+
+const VALID_THEMES: ThemeFlavor[] = ['catppuccin-latte', 'catppuccin-frappe', 'catppuccin-macchiato', 'catppuccin-mocha']
+
+export const useThemeStore = defineStore('theme', {
+  state: () => ({ currentTheme: 'catppuccin-mocha' as ThemeFlavor }),
+  getters: {
+    isDark(): boolean { return this.currentTheme !== 'catppuccin-latte' },
+    label(): string {
+      return {
+        'catppuccin-latte': 'Latte',
+        'catppuccin-frappe': 'Frappé',
+        'catppuccin-macchiato': 'Macchiato',
+        'catppuccin-mocha': 'Mocha'
+      }[this.currentTheme]
+    }
+  },
+  actions: {
+    applyTheme(flavor: ThemeFlavor) {
+      this.currentTheme = flavor
+      document.documentElement.setAttribute('data-theme', flavor)
+      document.documentElement.setAttribute('data-bulma-theme', flavor === 'catppuccin-latte' ? 'light' : 'dark')
+      localStorage.setItem('avhbs-theme', flavor)
+    },
+    init() {
+      const saved = localStorage.getItem('avhbs-theme') as ThemeFlavor
+      if (VALID_THEMES.includes(saved)) {
+        this.applyTheme(saved)
+        return
+      }
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      this.applyTheme(prefersDark ? 'catppuccin-mocha' : 'catppuccin-latte')
+    }
+  }
+})

--- a/frontend/src/views/Settings/AccountSettingsSingle.vue
+++ b/frontend/src/views/Settings/AccountSettingsSingle.vue
@@ -77,17 +77,26 @@
   <div class="columns">
     <div class="column is-3">Category:</div>
     <div class="column">
-      <div class="control has-icons-left">
-        <div class="select">
-          <select v-model="account.category">
-            <option value="0">All</option>
-            <option v-for="category in category$.accountCategories" :value="category.id" class="has-icons-left">
-              {{ category.title }}
-            </option>
-          </select>
+      <div class="dropdown is-hoverable">
+        <div class="dropdown-trigger">
+          <button class="button" aria-haspopup="true">
+            <span class="icon is-small">
+              <icon :icon="categoryIcon ?? ['fas', 'circle-info']" />
+            </span>
+            <span>{{ selectedCategoryLabel }}</span>
+            <span class="icon is-small">
+              <icon :icon="['fas', 'angle-down']" />
+            </span>
+          </button>
         </div>
-        <div class="icon is-small is-left">
-          <icon :icon="categoryIcon"/>
+        <div class="dropdown-menu">
+          <div class="dropdown-content">
+            <a v-for="cat in category$.accountCategories" :key="cat.id"
+               class="dropdown-item" :class="{ 'is-active': account.category === cat.id }"
+               @click="account.category = cat.id">
+              {{ cat.title }}
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -138,6 +147,16 @@
 
 </template>
 
+<style scoped>
+.dropdown-item.is-active {
+  background-color: transparent;
+  color: inherit;
+  font-weight: 600;
+  border-left: 3px solid hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l));
+  padding-left: calc(1rem - 3px);
+}
+</style>
+
 <script lang="ts">
 import { useAccountStore } from '../../store/AccountStore';
 import { useCategoryStore } from '../../store/CategoryStore';
@@ -175,6 +194,9 @@ export default {
   computed: {
     categoryIcon(){
       return this.category$.byId(this.account.category)?.icon
+    },
+    selectedCategoryLabel(){
+      return this.category$.byId(this.account.category)?.title ?? '—';
     },
     isEdit(){
       return this.$route.params.accountId?.toString().length > 0;

--- a/frontend/src/views/Settings/AccountSettingsSingle.vue
+++ b/frontend/src/views/Settings/AccountSettingsSingle.vue
@@ -77,28 +77,18 @@
   <div class="columns">
     <div class="column is-3">Category:</div>
     <div class="column">
-      <div class="dropdown is-hoverable">
-        <div class="dropdown-trigger">
-          <button class="button" aria-haspopup="true">
-            <span class="icon is-small">
-              <icon :icon="categoryIcon ?? ['fas', 'circle-info']" />
-            </span>
-            <span>{{ selectedCategoryLabel }}</span>
-            <span class="icon is-small">
-              <icon :icon="['fas', 'angle-down']" />
-            </span>
-          </button>
-        </div>
-        <div class="dropdown-menu">
-          <div class="dropdown-content">
-            <a v-for="cat in category$.accountCategories" :key="cat.id"
-               class="dropdown-item" :class="{ 'is-active': account.category === cat.id }"
-               @click="account.category = cat.id">
-              {{ cat.title }}
-            </a>
+      <div class="control has-icons-left">
+        <div class="select">
+          <select v-model="account.category">
+            <option v-for="category in category$.accountCategories" :value="category.id" class="has-icons-left">
+              {{ category.title }}
+            </option>
+          </select>
+          </div>
+           <div class="icon is-small is-left">
+            <icon :icon="categoryIcon"/>
           </div>
         </div>
-      </div>
     </div>
   </div>
 
@@ -194,9 +184,6 @@ export default {
   computed: {
     categoryIcon(){
       return this.category$.byId(this.account.category)?.icon
-    },
-    selectedCategoryLabel(){
-      return this.category$.byId(this.account.category)?.title ?? '—';
     },
     isEdit(){
       return this.$route.params.accountId?.toString().length > 0;


### PR DESCRIPTION
New theming system
  - Add Catppuccin flavor support (Latte, Frappé, Macchiato, Mocha) via catppuccin.scss, themeStore.ts, and ThemeSelector component
  - Theme selector added to the navbar
  - Primary color set to "Sky" blue
  - Remove old hardcoded --primary CSS variable from variables.scss

  UI improvements
  - Order panel: white/page-background body with colored header, primary-colored cart total, solid action buttons, left-border active indicator on account
  - Payment panel: consistent with order panel styling
  - Account settings: replace native <select> for Category with a custom styled dropdown matching the theme
