### PR TITLE
fix: replace Sass @import with @use in style.scss

### DIFF
--- a/frontend/src/assets/style.scss
+++ b/frontend/src/assets/style.scss
@@ -1,6 +1,6 @@
-@import "./variables.scss";
-@import "bulma/bulma";
-@import "./catppuccin.scss";
+@use "./variables.scss";
+@use "bulma/bulma";
+@use "./catppuccin.scss";
 
 .tag {
   white-space: break-spaces;


### PR DESCRIPTION
Replace deprecated Sass `@import` with `@use` in `style.scss` to fix Dart Sass deprecation warnings ahead of Sass 3.0.0 removal.