### PR TITLE
Fix #165: support partial values in WS update mutations

### DIFF
--- a/backend/internal/ws/helpers.go
+++ b/backend/internal/ws/helpers.go
@@ -60,17 +60,35 @@ func processInsertNoReturn[T any](ctx context.Context, s *Service, mutation *Mut
 	return b, id, wsErr
 }
 
-func processUpdate[T any](ctx context.Context, s *Service, mutation *Mutation, update func(context.Context, T) (int, error)) ([]byte, int, *WSError) {
-	item, wsErr := unmarshalInterface[T](mutation.Values)
-	if wsErr != nil {
-		return nil, 0, wsErr
+func processUpdate[T any](ctx context.Context, s *Service, mutation *Mutation, idField string, getByID func(context.Context, int) (*T, error), update func(context.Context, T) (int, error)) ([]byte, int, *WSError) {
+	idStr, ok := mutation.Where[idField]
+	if !ok {
+		return nil, 0, &WSError{Code: WSBadJSON, Message: "Missing " + idField + " in where clause", Details: "Update requires " + idField}
 	}
-	id, err := update(ctx, *item)
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil, 0, &WSError{Code: WSBadJSON, Message: err.Error(), Details: idField + " must be an integer"}
+	}
+
+	current, err := getByID(ctx, id)
+	if err != nil {
+		return nil, 0, &WSError{Code: WSDBQueryError, Message: err.Error(), Details: "Could not fetch current " + string(mutation.Table) + " for update"}
+	}
+
+	patch, err := json.Marshal(mutation.Values)
+	if err != nil {
+		return nil, 0, &WSError{Code: WSBadInterface, Message: err.Error(), Details: "Could not marshal patch values"}
+	}
+	if err := json.Unmarshal(patch, current); err != nil {
+		return nil, 0, &WSError{Code: WSBadJSON, Message: err.Error(), Details: "Could not apply patch to " + string(mutation.Table)}
+	}
+
+	newID, err := update(ctx, *current)
 	if err != nil {
 		return nil, 0, &WSError{Code: WSInternalError, Message: err.Error(), Details: "Could not update in " + string(mutation.Table)}
 	}
-	b, wsErr := s.marshalResultMutation(mutation.Table, mutation.Operation, id)
-	return b, id, wsErr
+	b, wsErr := s.marshalResultMutation(mutation.Table, mutation.Operation, newID)
+	return b, newID, wsErr
 }
 
 // processUpdateNoReturn handles updates for stores that return only error (composite-PK tables).

--- a/backend/internal/ws/processor.go
+++ b/backend/internal/ws/processor.go
@@ -143,23 +143,23 @@ func (s *Service) processMutation(ctx context.Context, mutation *Mutation) ([]by
 	case repo.OpUpdate:
 		switch mutation.Table {
 		case repo.TableAccount:
-			return processUpdate(ctx, s, mutation, s.stores.Account.Update)
+			return processUpdate(ctx, s, mutation, "account_id", s.stores.Account.GetByID, s.stores.Account.Update)
 		case repo.TableCategory:
-			return processUpdate(ctx, s, mutation, s.stores.Category.Update)
+			return processUpdate(ctx, s, mutation, "category_id", s.stores.Category.GetByID, s.stores.Category.Update)
 		case repo.TableFavorites:
 			return processUpdateNoReturn(ctx, s, mutation, 0, s.stores.Favorites.Update)
 		case repo.TableProduct:
-			return processUpdate(ctx, s, mutation, s.stores.Product.Update)
+			return processUpdate(ctx, s, mutation, "product_id", s.stores.Product.GetByID, s.stores.Product.Update)
 		case repo.TableProductGroup:
-			return processUpdate(ctx, s, mutation, s.stores.ProductGroup.Update)
+			return processUpdate(ctx, s, mutation, "product_group_id", s.stores.ProductGroup.GetByID, s.stores.ProductGroup.Update)
 		case repo.TableRights:
-			return processUpdate(ctx, s, mutation, s.stores.Rights.Update)
+			return processUpdate(ctx, s, mutation, "rights_id", s.stores.Rights.GetByID, s.stores.Rights.Update)
 		case repo.TableRole:
-			return processUpdate(ctx, s, mutation, s.stores.Role.Update)
+			return processUpdate(ctx, s, mutation, "role_id", s.stores.Role.GetByID, s.stores.Role.Update)
 		case repo.TableServiceLink:
 			return processUpdateNoReturn(ctx, s, mutation, 0, s.stores.ServiceLink.Update)
 		case repo.TableServiceSewobe:
-			return processUpdate(ctx, s, mutation, s.stores.ServiceSewobe.Update)
+			return processUpdate(ctx, s, mutation, "service_sewobe_id", s.stores.ServiceSewobe.GetByID, s.stores.ServiceSewobe.Update)
 		case repo.TableSettingsFrontend:
 			return processUpdateNoReturn(ctx, s, mutation, 0, s.stores.SettingsFrontend.Update)
 		case repo.TableSettingsPayment:
@@ -167,11 +167,11 @@ func (s *Service) processMutation(ctx context.Context, mutation *Mutation) ([]by
 		case repo.TableSettingsEmail:
 			return processUpdateNoReturn(ctx, s, mutation, 0, s.stores.SettingsEmail.Update)
 		case repo.TableUnit:
-			return processUpdate(ctx, s, mutation, s.stores.Unit.Update)
+			return processUpdate(ctx, s, mutation, "unit_id", s.stores.Unit.GetByID, s.stores.Unit.Update)
 		case repo.TableUser:
-			return processUpdate(ctx, s, mutation, s.stores.User.Update)
+			return processUpdate(ctx, s, mutation, "user_id", s.stores.User.GetByID, s.stores.User.Update)
 		case repo.TableVat:
-			return processUpdate(ctx, s, mutation, s.stores.Vat.Update)
+			return processUpdate(ctx, s, mutation, "vat_id", s.stores.Vat.GetByID, s.stores.Vat.Update)
 		}
 
 	case repo.OpDelete:


### PR DESCRIPTION
This PR fixes #165 

`processUpdate` unmarshalled `mutation.Values` directly into the full model struct. Partial payloads (e.g. `{enabled: false}`) produced a zero-value struct with `ID = 0`, so the SQL `WHERE account_id = 0` matched no rows, hence "no rows in result set".

`processUpdate` now requires an `x_id` entry in the `where` clause. It fetches the current record from the DB via `GetByID` and applies `mutation.Values` as a JSON patch on top. Go's `json.Unmarshal` only touches keys present in the patch, so unset fields are preserved from the DB record.